### PR TITLE
Parse urls from a Stream webpage html file

### DIFF
--- a/polidown.js
+++ b/polidown.js
@@ -495,9 +495,9 @@ function extractUrls(filePage){
     var re = /\/video\/.{36}/g;
     var urls = text.match(re);
 
-    if(urls.size == 0){
+    if(urls === null){
         console.log("!No valid url found in file: " + filePage);
-        exit();
+        process.exit();
     }
 
     // remove duplicates


### PR DESCRIPTION
Allows multiple video download parsing urls from an html file, passing its filename/full path with the -f option. 
This way you can search for a course on Stream, save the results page and download all the videos without copy-pasting the links

-f and -v are made mutually exclusive, but one of the two is required.